### PR TITLE
support restore animations

### DIFF
--- a/turn.css
+++ b/turn.css
@@ -1,39 +1,59 @@
 [data-turn-exit],
-[data-turn-enter] {
+[data-turn-enter],
+[data-turn-restore-exit],
+[data-turn-restore-enter] {
   animation-timing-function: cubic-bezier(0.65, 0.05, 0.35, 1);
   animation-fill-mode: forwards;
 }
 
+html.turn-restore-exit [data-turn-exit],
 html.turn-exit [data-turn-exit] {
-  animation-name: fade-out-up;
-  animation-duration: .3s;
+  animation-name: fade-scale-out;
+  animation-duration: .2s;
 }
 
 html.turn-enter [data-turn-enter] {
-  animation-name: fade-in-up;
-  animation-duration: .6s;
+  animation-name: fade-in-down;
+  animation-duration: .4s;
 }
 
-@keyframes fade-out-up {
-  0% {
-   opacity: 1;
-   transform: translateZ(0)
-  }
+html.turn-restore-enter [data-turn-enter] {
+  animation-name: fade-scale-in;
+  animation-duration: .2s;
+}
 
-  100% {
+@keyframes fade-in-down {
+  0% {
    opacity: 0;
    transform: translate3d(0, -4rem, 0)
   }
-}
-
-@keyframes fade-in-up {
-  0% {
-   opacity: 0;
-   transform: translate3d(0, 4rem, 0)
-  }
 
   100% {
    opacity: 1;
    transform: translateZ(0)
+  }
+}
+
+@keyframes fade-scale-in {
+  0% {
+   opacity: 0;
+   transform: scale(90%)
+  }
+
+  100% {
+   opacity: 1;
+   transform: scale(1)
+  }
+}
+
+@keyframes fade-scale-out {
+  0% {
+   opacity: 1;
+/*    transform: translateZ(0) */
+  }
+
+  100% {
+   opacity: 0;
+   transform: scale(90%)
   }
 }

--- a/turn.js
+++ b/turn.js
@@ -33,8 +33,6 @@ class Turn {
   }
 
   async beforeEnter (event) {
-    if (this.action === 'restore') return
-
     event.preventDefault()
 
     if (this.isPreview) {
@@ -63,7 +61,7 @@ class Turn {
   }
 
   get shouldAnimateEnter () {
-    if (this.action === 'restore') return false
+    if (this.action === 'restore') return true
     if (this.isPreview) return true
     if (this.hasPreview) return false
     return true
@@ -73,9 +71,14 @@ class Turn {
     return document.documentElement.hasAttribute('data-turbo-preview')
   }
 
-  addClasses (type) {
-    document.documentElement.classList.add(`turn-${type}`)
+  className (type) {
+    if (this.action === 'restore') return `turn-restore-${type}`
+    return `turn-${type}`
+  }
 
+  addClasses (type) {
+    document.documentElement.classList.add(this.className(type))
+    // debugger;
     Array.from(document.querySelectorAll(`[data-turn-${type}]`)).forEach((element) => {
       (element.dataset[`turn${capitalize(type)}`]).split(/\s+/).forEach((klass) => {
         if (klass) {
@@ -87,8 +90,7 @@ class Turn {
   }
 
   removeClasses (type) {
-    document.documentElement.classList.remove(`turn-${type}`)
-
+    document.documentElement.classList.remove(this.className(type))
     Array.from(document.querySelectorAll(`[data-turn-${type}]`)).forEach((element) => {
       this[`${type}Classes`].forEach((klass) => element.classList.remove(klass))
     })


### PR DESCRIPTION
You might consider allowing animations on "restore", instead of preventing them. 

In the updated example:
- advance enter: fade-in-down (visually simulates downloading from the cloud)
- exit: fade-scale-out (visually simulates storing to local history)
- restore enter: fade-scale-in (visually simulates pulling out of local history)

![turn](https://user-images.githubusercontent.com/1099993/169087502-cfc056c3-6110-4515-a8ab-e7a0a07e21db.gif)

I'd love to be able to slide animations left and right depending on if the user pressed forward/back for restorations visits, but couldn't figure out how to do that.