### PR TITLE
bugfix(package): add type module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@domchristie/turn",
-  "version": "2.0.0-0",
+  "version": "2.0.1",
+  "type": "module",
   "description": "Animate page transitions in Turbo Drive apps.",
   "main": "dist/turn.min.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domchristie/turn",
-  "version": "2.0.1",
+  "version": "2.0.0-0",
   "type": "module",
   "description": "Animate page transitions in Turbo Drive apps.",
   "main": "dist/turn.min.js",


### PR DESCRIPTION
@domchristie/turn doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.